### PR TITLE
Bump version to 0.2.12 for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRKGaussLegendre"
 uuid = "58bc7355-f626-4c51-96f2-1f8a038f95a2"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["joseba <mikel.antonana@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary
- Bumps version from 0.2.11 to 0.2.12 in Project.toml for release

### Changes since v0.2.11
- Performance improvements with PolInterp! in-place variant (#97)
- Allocation tests for core functions (#97)  
- Documentation improvements (#96)
- Migration to Dependabot (#92)
- Bump actions/checkout from 4 to 6 (#91)

## Registration

After this PR is merged, @ChrisRackauckas should comment on the merge commit with:

```
@JuliaRegistrator register
```

Note: The previous registration attempt failed because ChrisRackauckas-Claude is not a publicly listed member of the SciML organization. Only a public member of SciML can trigger the registration.

Closes #98

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)