### PR TITLE
Bump SciMLBase compat to v3 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRKGaussLegendre"
 uuid = "58bc7355-f626-4c51-96f2-1f8a038f95a2"
-version = "0.2.13"
+version = "0.3.0"
 authors = ["joseba <mikel.antonana@gmail.com>"]
 
 [deps]
@@ -21,7 +21,7 @@ Parameters = "0.12"
 #RecursiveArrayTools = "3"
 Reexport = "1.0"
 SIMD = "3.5.0"
-SciMLBase = "2"
+SciMLBase = "2, 3"
 julia = "1.9"
 
 [extras]


### PR DESCRIPTION
## Summary
- Update SciMLBase compat bounds to include v3
- Bump package version 0.2.13 → 0.3.0 (minor)
- No code changes needed - package doesn't use deprecated SciMLBase v2 patterns

Supersedes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)