### PR TITLE
Widen DiffEqBase compat to allow v7 (DifferentialEquations.jl v8 ecosystem)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 
 [compat]
 AllocCheck = "0.1, 0.2"
-DiffEqBase = "6.217"
+DiffEqBase = "6.217, 7"
 Parameters = "0.12"
 Reexport = "1.0"
 SIMD = "3.5.0"


### PR DESCRIPTION
## Summary

The major bump to v0.3.0 (#113) was version-only and inherited the prior `DiffEqBase = "6.217"` cap, which blocks **DiffEqBase v7** — the v7 ecosystem release that ships with SciMLBase v3, OrdinaryDiffEq v7, RecursiveArrayTools v4, DelayDiffEq v6, StochasticDiffEq v7, etc. (DifferentialEquations.jl v8 meta-release).

The package's compat already advertises `SciMLBase = "2, 3.1"`, but without `DiffEqBase = "6.217, 7"` the resolver cannot actually pick the v3-line install — anyone trying to use IRKGaussLegendre v0.3.0 alongside the rest of the v7 ecosystem hits an unsatisfiable resolve.

This single-line bump closes that gap.

## Changes

- `Project.toml`: `DiffEqBase = "6.217"` → `"6.217, 7"`

## Verification

Local resolve against the now-registered v7 ecosystem:

```
DiffEqBase           v7.0.0
SciMLBase            v3.6.0
RecursiveArrayTools  v4.2.0
```

Note: an existing `Allocation Tests` failure with `UndefVarError: PolInterp! not defined` is **pre-existing on master** (test imports `PolInterp!` with a bang while the source defines `PolInterp` without) — this PR does not introduce or fix that. Filed separately if not already.

## Test plan

- [ ] CI green on the test jobs not affected by the pre-existing PolInterp! issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)