### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,13 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,20 +13,8 @@ on:
 jobs:
   test:
     if: false  # Disabled: waiting on dependency updates. See issue for details.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Converts the repo's CI to use the centralized SciML reusable workflows for everything, pinned at `@v1`, with `secrets: "inherit"` on every caller.

## Converted (inline -> central)
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1`, preserving `julia-version: "1.10"`, `skip: "Pkg,TOML"`, and the existing job-level `if: false` (the workflow remains disabled exactly as before)

## Added
- **Documentation.yml**: new `documentation.yml@v1` caller (the repo has `docs/make.jl` but had no documentation workflow)

## Unchanged
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"` and the `version: ["1", "lts", "pre"]` matrix — left as is
- **TagBot.yml**: unchanged

## Other
- **dependabot.yml**: removed the `crate-ci/typos` version ignore (the central spellcheck workflow pins its own typos version); dropped `/test` from the `julia` ecosystem `directories` because `test/` has no `Project.toml` (test deps live in the main `Project.toml` extras). Kept `/` and `/docs`.

## Formatting / spelling
- Ran Runic 1 inplace: **no changes** (already clean from the prior inline Runic check).
- Ran `typos`: **0 findings**, no fixes needed.

## Note on required checks
Check names change with this conversion (jobs now run as reusable-workflow callers). Branch-protection required-status-check names will need updating to match the new caller names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)