### PR TITLE
Format: apply Runic to fix format check

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,7 +55,7 @@ else
     u0[:, :, 1] = q0
     u0[:, :, 2] = v0
     tspan = (0.0, 63.0)
-    prob = ODEProblem(NbodyODE!, u0, tspan, Gm);
+    prob = ODEProblem(NbodyODE!, u0, tspan, Gm)
     sol1 = solve(prob, IRKGL16(), reltol = 1.0e-12, abstol = 1.0e-12)
 
     # Analytical tests


### PR DESCRIPTION
Formatting-only PR to fix the failing Runic format check.

The repo's `format-check` CI runs Runic (`fredrikekre/runic-action@v1` / `SciML/.github/.github/workflows/runic.yml@v1`) with default settings (extensions `jl`, no docstring formatting). The check is currently failing.

This applies Runic v1.7.0 (the version `version: '1'` resolves to) in place over all git-tracked `.jl` files, matching exactly how CI selects and formats files. No semantic/code changes — verified that diffs are whitespace/formatting only (`git diff --ignore-all-space` is empty for the larger reindent). Re-running Runic in `--check` mode after formatting passes with exit code 0.

Ignore until reviewed by @ChrisRackauckas.