### PR TITLE
Canonicalize test units with @safetestset for isolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ ODEProblemLibrary = "1"
 Parameters = "0.12, 0.13"
 Reexport = "1.2.2"
 SIMD = "3.5.0"
+SafeTestsets = "0.1, 1"
 SciMLBase = "3.1"
 SciMLLogging = "1.10.1, 2"
 Test = "1"
@@ -29,7 +30,8 @@ julia = "1.10"
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "DiffEqDevTools", "ODEProblemLibrary", "Test"]
+test = ["AllocCheck", "DiffEqDevTools", "ODEProblemLibrary", "SafeTestsets", "Test"]

--- a/test/main_tests.jl
+++ b/test/main_tests.jl
@@ -1,0 +1,92 @@
+using Test
+using IRKGaussLegendre, ODEProblemLibrary, DiffEqDevTools
+import ODEProblemLibrary: prob_ode_2Dlinear, prob_ode_bigfloat2Dlinear
+
+function NbodyODE!(F, u, Gm, t)
+    N = length(Gm)
+    for i in 1:N
+        for k in 1:3
+            F[k, i, 2] = 0
+        end
+    end
+    for i in 1:N
+        xi = u[1, i, 1]
+        yi = u[2, i, 1]
+        zi = u[3, i, 1]
+        Gmi = Gm[i]
+        for j in (i + 1):N
+            xij = xi - u[1, j, 1]
+            yij = yi - u[2, j, 1]
+            zij = zi - u[3, j, 1]
+            Gmj = Gm[j]
+            dotij = (xij * xij + yij * yij + zij * zij)
+            auxij = 1 / (sqrt(dotij) * dotij)
+            Gmjauxij = Gmj * auxij
+            F[1, i, 2] -= Gmjauxij * xij
+            F[2, i, 2] -= Gmjauxij * yij
+            F[3, i, 2] -= Gmjauxij * zij
+            Gmiauxij = Gmi * auxij
+            F[1, j, 2] += Gmiauxij * xij
+            F[2, j, 2] += Gmiauxij * yij
+            F[3, j, 2] += Gmiauxij * zij
+        end
+    end
+    for i in 1:3, j in 1:N
+
+        F[i, j, 1] = u[i, j, 2]
+    end
+    return nothing
+end
+
+Gm = [5, 4, 3]
+N = length(Gm)
+q = [1, -1, 0, -2, -1, 0, 1, 3, 0]
+v = zeros(size(q))
+q0 = reshape(q, 3, :)
+v0 = reshape(v, 3, :)
+u0 = Array{Float64}(undef, 3, N, 2)
+u0[:, :, 1] = q0
+u0[:, :, 2] = v0
+tspan = (0.0, 63.0)
+prob = ODEProblem(NbodyODE!, u0, tspan, Gm)
+sol1 = solve(prob, IRKGL16(), reltol = 1.0e-12, abstol = 1.0e-12)
+
+# Analytical tests
+
+sol = solve(prob_ode_2Dlinear, IRKGL16())
+@test sol.errors[:l2] < 1.0e-16
+
+# dts = (1 // 2) .^ (4:-1:2)
+dts = BigFloat.((1 // 2) .^ (3:-1:1))
+sim = test_convergence(dts, prob_ode_bigfloat2Dlinear, IRKGL16())
+@test abs(sim.𝒪est[:final] - 16) < 0.5
+
+# Backward integrations tests
+
+#Define the problem
+const g = 9.81
+L = 1.0
+u0 = [0, pi / 2]
+function simplependulum(du, u, p, t)
+    θ = u[1]
+    dθ = u[2]
+    du[1] = dθ
+    return du[2] = -(g / L) * sin(θ)
+end
+
+# adaptive=true
+
+tspan = (6.3, 2.0)
+prob = ODEProblem(simplependulum, u0, tspan)
+sol = solve(prob, IRKGL16(), reltol = 1.0e-14, abstol = 1.0e-14)
+
+@test sol.t[end] == tspan[2]
+
+# adaptive=false
+
+tspan = (6.3, 2.0)
+dt0 = -0.1
+prob = ODEProblem(simplependulum, u0, tspan)
+sol = solve(prob, IRKGL16(), dt = dt0, adaptive = false)
+
+@test sol.t[end] == tspan[2]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -3,6 +3,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 IRKGaussLegendre = "58bc7355-f626-4c51-96f2-1f8a038f95a2"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -11,5 +12,6 @@ IRKGaussLegendre = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -6,15 +6,17 @@ let Pkg = Base.require(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78
     Pkg.instantiate()
 end
 
-using IRKGaussLegendre, Aqua, JET, Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using IRKGaussLegendre, Aqua, Test
     # deps_compat disabled: missing [compat] entry for the LinearAlgebra stdlib dep.
     # Tracked in https://github.com/SciML/IRKGaussLegendre.jl/issues/124
     Aqua.test_all(IRKGaussLegendre; deps_compat = false)
     @test_broken false  # Aqua deps_compat: missing compat for LinearAlgebra — tracked in https://github.com/SciML/IRKGaussLegendre.jl/issues/124
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using IRKGaussLegendre, JET, Test
     JET.test_package(IRKGaussLegendre; target_defined_modules = true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,105 +1,19 @@
 using Test
-using IRKGaussLegendre, ODEProblemLibrary, DiffEqDevTools
-import ODEProblemLibrary: prob_ode_2Dlinear, prob_ode_bigfloat2Dlinear
+using SafeTestsets
 
 const GROUP = get(ENV, "GROUP", "All")
 
 if GROUP == "QA"
-    @testset "Quality Assurance" begin
+    @safetestset "Quality Assurance" begin
         include(joinpath(@__DIR__, "qa", "qa.jl"))
     end
 else
-    function NbodyODE!(F, u, Gm, t)
-        N = length(Gm)
-        for i in 1:N
-            for k in 1:3
-                F[k, i, 2] = 0
-            end
-        end
-        for i in 1:N
-            xi = u[1, i, 1]
-            yi = u[2, i, 1]
-            zi = u[3, i, 1]
-            Gmi = Gm[i]
-            for j in (i + 1):N
-                xij = xi - u[1, j, 1]
-                yij = yi - u[2, j, 1]
-                zij = zi - u[3, j, 1]
-                Gmj = Gm[j]
-                dotij = (xij * xij + yij * yij + zij * zij)
-                auxij = 1 / (sqrt(dotij) * dotij)
-                Gmjauxij = Gmj * auxij
-                F[1, i, 2] -= Gmjauxij * xij
-                F[2, i, 2] -= Gmjauxij * yij
-                F[3, i, 2] -= Gmjauxij * zij
-                Gmiauxij = Gmi * auxij
-                F[1, j, 2] += Gmiauxij * xij
-                F[2, j, 2] += Gmiauxij * yij
-                F[3, j, 2] += Gmiauxij * zij
-            end
-        end
-        for i in 1:3, j in 1:N
-
-            F[i, j, 1] = u[i, j, 2]
-        end
-        return nothing
+    @safetestset "IRKGL16 Solver" begin
+        include("main_tests.jl")
     end
-
-    Gm = [5, 4, 3]
-    N = length(Gm)
-    q = [1, -1, 0, -2, -1, 0, 1, 3, 0]
-    v = zeros(size(q))
-    q0 = reshape(q, 3, :)
-    v0 = reshape(v, 3, :)
-    u0 = Array{Float64}(undef, 3, N, 2)
-    u0[:, :, 1] = q0
-    u0[:, :, 2] = v0
-    tspan = (0.0, 63.0)
-    prob = ODEProblem(NbodyODE!, u0, tspan, Gm)
-    sol1 = solve(prob, IRKGL16(), reltol = 1.0e-12, abstol = 1.0e-12)
-
-    # Analytical tests
-
-    sol = solve(prob_ode_2Dlinear, IRKGL16())
-    @test sol.errors[:l2] < 1.0e-16
-
-    # dts = (1 // 2) .^ (4:-1:2)
-    dts = BigFloat.((1 // 2) .^ (3:-1:1))
-    sim = test_convergence(dts, prob_ode_bigfloat2Dlinear, IRKGL16())
-    @test abs(sim.𝒪est[:final] - 16) < 0.5
-
-    # Backward integrations tests
-
-    #Define the problem
-    const g = 9.81
-    L = 1.0
-    u0 = [0, pi / 2]
-    function simplependulum(du, u, p, t)
-        θ = u[1]
-        dθ = u[2]
-        du[1] = dθ
-        return du[2] = -(g / L) * sin(θ)
-    end
-
-    # adaptive=true
-
-    tspan = (6.3, 2.0)
-    prob = ODEProblem(simplependulum, u0, tspan)
-    sol = solve(prob, IRKGL16(), reltol = 1.0e-14, abstol = 1.0e-14)
-
-    @test sol.t[end] == tspan[2]
-
-    # adaptive=false
-
-    tspan = (6.3, 2.0)
-    dt0 = -0.1
-    prob = ODEProblem(simplependulum, u0, tspan)
-    sol = solve(prob, IRKGL16(), dt = dt0, adaptive = false)
-
-    @test sol.t[end] == tspan[2]
 
     # Allocation tests (run separately to avoid precompilation interference)
-    @testset "Allocation Tests" begin
+    @safetestset "Allocation Tests" begin
         include("alloc_tests.jl")
     end
 end


### PR DESCRIPTION
## Summary

Converts the plain-`@testset` test units to `@safetestset` so each independent test unit runs in its own module (test isolation + world-age safety), matching the canonical SciML/OrdinaryDiffEq test structure.

### Changes
- **`test/runtests.jl`**: The `else` (non-QA) branch previously held a large block of *loose, top-level* solver test code (N-body setup, analytical convergence test, backward-integration tests) running directly in `Main`, followed by a nested `@testset "Allocation Tests"`. That loose block is extracted verbatim into a new self-contained `test/main_tests.jl` and wrapped as `@safetestset "IRKGL16 Solver" begin include("main_tests.jl") end`. The `Allocation Tests` and `Quality Assurance` includes become `@safetestset`.
- **`test/main_tests.jl`** (new): the extracted solver test block, with its own `using IRKGaussLegendre, ODEProblemLibrary, DiffEqDevTools` / `import ODEProblemLibrary: ...` / `using Test` so the fresh `@safetestset` module is self-contained.
- **`test/qa/qa.jl`**: the `Aqua` and `JET` `@testset`s become `@safetestset`, each carrying its own imports. The `Pkg.activate`/`instantiate` block and the `@test_broken` are preserved unchanged.
- **Deps**: `SafeTestsets` added to the root `Project.toml` (`[extras]`, `[targets].test`, `[compat] SafeTestsets = "0.1, 1"`) and to `test/qa/Project.toml` (the QA group activates its own env).

### Behavior preserved
Same tests run, same assertions, same `GROUP` dispatch ladder (`QA` vs everything-else). `alloc_tests.jl` already carried its own imports and is unchanged; its two inner `@testset`s remain plain (the unit-level `@safetestset` already isolates them).

### Verification (local, julia 1.11)
- `GROUP=Core`: `IRKGL16 Solver` 4/4 pass, `Allocation Tests` 6/6 pass.
- `GROUP=QA`: `Quality Assurance` 8 pass, 1 broken (the pre-existing `@test_broken`).

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)