### PR TITLE
docs: add IRKGL16 docstring; fix __solve undefined-variable bug (QA/JET green)

### DIFF
--- a/src/IRKGL16Solver.jl
+++ b/src/IRKGL16Solver.jl
@@ -99,6 +99,32 @@ struct IRKGL16{
         maxtrials,
         initial_extrapolation,
     } end
+"""
+    IRKGL16(; s = 8, second_order_ode = false, simd = true, fseq = true,
+            maxtrials = 5, initial_extrapolation = true)
+
+A 16th order implicit Runge-Kutta Gauss-Legendre integrator for high-precision
+numerical integration of non-stiff ODE systems. The default 8-stage scheme is
+based on Gauss-Legendre nodes, making it symplectic and well-suited for
+Hamiltonian and other geometric-structure-preserving problems.
+
+## Keyword Arguments
+
+  - `s`: Number of stages (default `8`, giving 16th order accuracy).
+  - `second_order_ode`: Set to `true` for second-order differential equations
+    (default `false`).
+  - `simd`: Enable the SIMD-vectorized implementation for `Float32`/`Float64`
+    state (default `true`).
+  - `fseq`: Use the hybrid step implementation (default `true`).
+  - `maxtrials`: Maximum number of attempts to accept an adaptive step size
+    (default `5`).
+  - `initial_extrapolation`: Use extrapolation from the previous step for stage
+    initialization (default `true`).
+
+Step-size control and tolerances (`dt`, `adaptive`, `abstol`, `reltol`,
+`maxiters`, `saveat`, `save_everystep`) are passed to `solve` as common solver
+keyword arguments.
+"""
 function IRKGL16(;
         s = 8,
         second_order_ode = false,

--- a/src/IRKGL16Solver.jl
+++ b/src/IRKGL16Solver.jl
@@ -190,8 +190,9 @@ function SciMLBase.__solve(
     stats.naccept = 0
     stats.nreject = 0
 
+    @unpack u0, tspan, p = prob
+
     if (prob.f isa ODEFunction)
-        @unpack u0, tspan, p = prob
         f = SciMLBase.unwrapped_f(prob.f)
     else
         @SciMLMessage("Error: incorrect ODEFunction", verbose, :mismatched_input_output_type)
@@ -206,11 +207,16 @@ function SciMLBase.__solve(
 
     tType = eltype(tspanType)
     realuType = typeof(real(u0))
+    floatType = eltype(u0)
+    # The SIMD code paths only apply to Float32/Float64 state; for any other
+    # element type (e.g. BigFloat) we fall back to the generic implementation,
+    # regardless of the `simd` algorithm option. Compute the predicate once and
+    # reuse it so cache construction and saveat interpolation stay consistent.
+    use_simd = simd && eltype(u0) <: Union{Float32, Float64}
 
     step_fun::Function = empty
 
-    if simd && eltype(u0) <: Union{Float32, Float64}
-        floatType = eltype(u0)
+    if use_simd
         if !adaptive
             if !second_order_ode
                 if !fseq
@@ -292,8 +298,11 @@ function SciMLBase.__solve(
     step_number[] = 0
     length_u = length(u0)
     length_q = div(length_u, 2)
+    # Backing buffer for SIMD `saveat` interpolation; only populated on the
+    # `use_simd` path, but bound on every path so it is always defined.
+    kappa_ = floatType[]
 
-    if simd && eltype(u0) <: Union{Float32, Float64}
+    if use_simd
         coeffs = tcoeffs{tType}(
             zeros(s, s), zeros(s), zeros(s), zeros(s, s),
             zeros(s), zeros(s + 1), zeros(s, s + 1), zeros(s),
@@ -505,7 +514,7 @@ function SciMLBase.__solve(
                 theta = abs((save_times[next_save_index] - tj_) / dts[2])
                 Z2 .= [theta]
 
-                if !simd
+                if !use_simd
                     kappa .= (PolInterp(X2, Y2, Z2))
                     for k in indices
                         dUik = kappa[1] * L[1][k]
@@ -550,7 +559,7 @@ function SciMLBase.__solve(
                 theta = abs((save_times[next_save_index] - tj_) / dts[2])
                 Z2 .= [theta]
 
-                if !simd
+                if !use_simd
                     kappa .= (PolInterp(X2, Y2, Z2))
                     for k in indices
                         dUik = kappa[1] * L[1][k]


### PR DESCRIPTION
## Problem

The `Documentation / Build and Deploy Documentation` check on `master` is failing:

```
Error: no docs found for 'IRKGL16' in `@docs` block in docs/src/index.md:40-42
ERROR: LoadError: `makedocs` encountered an error [:docs_block] -- terminating build before rendering.
```

`docs/src/index.md` has an `@docs` block referencing `IRKGL16`, but the
`IRKGL16` type/constructor had no docstring attached anywhere in `src/`, so
Documenter aborted the build.

## Fix

Add a docstring to the `IRKGL16` keyword constructor in
`src/IRKGL16Solver.jl`, describing the algorithm and its keyword options
(consistent with the options already documented in `index.md`). This makes the
`@docs IRKGL16` block resolve.

## Local verification

```
$ julia +1.10 --project=docs docs/make.jl
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: Doctest: running doctests.
[ Info: ExpandTemplates: expanding markdown templates.
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
EXIT=0
```

The build now completes RenderDocument/HTMLWriter (previously errored at
`:docs_block`). Runic format check passes on the edited file.

## Scope note

This PR fixes only the Documentation build. The separate `Tests / QA` failure
on `master` is a distinct, pre-existing issue: JET (`JET.test_package`, newly
wired in #123) reports genuine "possible undefined variable" findings in
`SciMLBase.__solve` (`u0` in the non-ODEFunction error branch, plus
`floatType`/`kappa_` across correlated `simd` conditionals). That is a
solver-internals concern requiring its own reviewed change and full solver test
runs; it is intentionally out of scope here to keep this PR small.

Please ignore until reviewed by @ChrisRackauckas.

---

## Additional fix: QA (JET) failure on Julia 1.12

The `tests / QA (julia 1)` check (now Julia 1.12) was red because
`JET.test_package` reported 14 `report_package` errors in
`SciMLBase.__solve` (`src/IRKGL16Solver.jl`). These were **true positives**,
not false positives:

- `u0` was referenced in the error-return branch but only `@unpack`-ed inside
  the `prob.f isa ODEFunction` success branch (would `UndefVarError` if a
  non-`ODEFunction` problem ever reached it).
- The `saveat` interpolation branched on the bare `simd` algorithm option,
  while the cache was built on `simd && eltype(u0) <: Union{Float32,Float64}`.
  For non-Float32/Float64 state (e.g. `BigFloat`) the generic cache was built
  but the SIMD interpolation branch ran, hitting `UndefVarError: kappa_` at
  runtime whenever `saveat` was supplied. Reproduced on a clean checkout:
  `solve(BigFloat ODEProblem, IRKGL16(), saveat = ...)` errors with
  `UndefVarError: kappa_ not defined`.

### Fix

- `@unpack u0, tspan, p = prob` on all paths.
- Introduce `use_simd = simd && eltype(u0) <: Union{Float32,Float64}` and use it
  consistently for cache construction and `saveat` interpolation.
- Bind `floatType` and `kappa_` on every path so they are always defined.

No JET reports were suppressed; the source was fixed.

### Local verification (this machine)

- JET: `JET.test_package(IRKGaussLegendre; target_defined_modules = true)` —
  **passes** on both Julia 1.12.6 and 1.10.11 (was 14 errors on 1.12).
- Full QA group (`Pkg.test`, GROUP=QA) on 1.12: `QA/qa.jl 8 pass, 1 broken`
  (the 1 broken is the pre-existing Aqua `deps_compat` item, issue #124).
- Full Core group on 1.12: `Core/alloc_tests.jl 6/6`, `Core/main_tests.jl 4/4`.
- Runtime smoke tests: SIMD+saveat, BigFloat+saveat (previously crashing),
  simd=false+saveat all return `Success` with correct results.

Please ignore until reviewed by @ChrisRackauckas.