### PR TITLE
Bump version to 1.0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRKGaussLegendre"
 uuid = "58bc7355-f626-4c51-96f2-1f8a038f95a2"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["joseba <mikel.antonana@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (1.0.2 -> 1.0.3) to release unreleased commits on `master` via JuliaRegistrator.