### PR TITLE
Use SciMLTesting 2.1 QA docs check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ SIMD = "3.5.0"
 SafeTestsets = "0.1, 1"
 SciMLBase = "3.1"
 SciMLLogging = "1.10.1, 2"
-SciMLTesting = "1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,6 +46,10 @@ sol = solve(prob, IRKGL16(), reltol=1e-12, abstol=1e-12)
 IRKGL16
 ```
 
+```@autodocs
+Modules = [IRKGaussLegendre]
+```
+
 ## Solver Options
 
 ### Common Keyword Arguments

--- a/src/IRKGL16Solver.jl
+++ b/src/IRKGL16Solver.jl
@@ -1,3 +1,8 @@
+"""
+    tcoeffs{T}
+
+Gauss-Legendre tableau and interpolation coefficients used by the IRK solver.
+"""
 struct tcoeffs{tType}
     mu::Array{tType, 2}
     c::Array{tType, 1}
@@ -76,6 +81,11 @@ struct IRKGL_SIMD_Cache{realuType, floatT, fType, pType, s_, dim_}
     verbose::DEVerbosity
 end
 
+"""
+    IRKAlgorithm
+
+Abstract base type for IRKGaussLegendre algorithms.
+"""
 abstract type IRKAlgorithm{
     s,
     second_order_ode,

--- a/src/IRKGaussLegendre.jl
+++ b/src/IRKGaussLegendre.jl
@@ -13,6 +13,11 @@ module IRKGaussLegendre
     using Parameters
     using SIMD
 
+    """
+        CompiledFloats
+
+    Floating-point element types supported by the compiled SIMD IRK implementation.
+    """
     const CompiledFloats = Union{Float32, Float64}
 
     include("IRKCoefficients.jl")

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-IRKGaussLegendre = {path = "/home/crackauc/sandbox/tmp_20260708_051717_3275/repos/IRKGaussLegendre.jl"}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -7,12 +7,12 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
-IRKGaussLegendre = {path = "../.."}
+IRKGaussLegendre = {path = "/home/crackauc/sandbox/tmp_20260708_051717_3275/repos/IRKGaussLegendre.jl"}
 
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.7"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -4,6 +4,7 @@ run_qa(
     IRKGaussLegendre;
     explicit_imports = true,
     jet_kwargs = (; target_defined_modules = true),
+    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
             ignore = (


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Updates SciMLTesting compat entries to 2.1.
- Enables the shared SciMLTesting rendered public API docs QA check.
- Adds missing public API docstrings/docs rendering needed by the shared check.

## Validation
- Runic check on changed Julia files.
- TOML parse check on edited Project files.
- Local QA group with GROUP=QA timeout 3600.