### PR TITLE
Release prep: bump IRKGaussLegendre to 1.0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRKGaussLegendre"
 uuid = "58bc7355-f626-4c51-96f2-1f8a038f95a2"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["joseba <mikel.antonana@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test-scaffolding changes since 1.0.3 (no functional/API changes).