### PR TITLE
Restore and document the SciML common interface as explicit exports

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,3 +10,27 @@ IRKAlgorithm
 CompiledFloats
 tcoeffs
 ```
+
+## Reexported SciML common interface
+
+`using IRKGaussLegendre` also brings in the parts of the SciML common interface needed to
+build an ODE problem, solve it with `IRKGL16`, and inspect the result, so they do not
+have to be imported separately — this is what the Quick Start example in the README
+relies on. These names are owned and documented by
+[SciMLBase](https://docs.sciml.ai/SciMLBase/stable/):
+
+  - Problems: `ODEProblem`, `EnsembleProblem`
+  - Functions: `ODEFunction`
+  - Solutions: `ODESolution`, `EnsembleSolution`, `EnsembleSummary`, `DEStats`
+  - Ensemble algorithms: `EnsembleSerial`, `EnsembleThreads`, `EnsembleDistributed`,
+    `EnsembleSplitThreads`, and the `EnsembleAnalysis` module
+  - Solving: `solve`, `remake`
+  - Return status: `ReturnCode`, `successful_retcode`
+  - `NullParameters`
+
+Callbacks and the iterator interface are deliberately *not* reexported: `IRKGL16`
+implements only `solve` and honors no `callback` keyword, so those names would resolve to
+methods that cannot be used with this solver. Second-order systems are handled by passing
+`second_order_ode = true` to `IRKGL16` alongside an ordinary `ODEProblem`, so
+`SecondOrderODEProblem` is not part of this surface either. Anything else from SciMLBase
+must be imported from SciMLBase directly.

--- a/src/IRKGaussLegendre.jl
+++ b/src/IRKGaussLegendre.jl
@@ -3,8 +3,18 @@ __precompile__()
 module IRKGaussLegendre
 
     import SciMLBase
-    using SciMLBase: ODEFunction, ReturnCode
     using DiffEqBase: DEVerbosity
+
+    # The SciML common interface that IRKGaussLegendre reexports (see the second
+    # `export` below), so that `using IRKGaussLegendre` on its own is enough to build an
+    # ODE problem, solve it with `IRKGL16`, and inspect the result -- which is exactly
+    # what the README's Quick Start and the docs examples do. Callbacks and the iterator
+    # interface are deliberately absent: this solver implements only `__solve` and
+    # honors no `callback` keyword. Every name stays owned and documented upstream.
+    using SciMLBase: DEStats, EnsembleAnalysis, EnsembleDistributed, EnsembleProblem,
+        EnsembleSerial, EnsembleSolution, EnsembleSplitThreads, EnsembleSummary,
+        EnsembleThreads, NullParameters, ODEFunction, ODEProblem, ODESolution,
+        ReturnCode, remake, solve, successful_retcode
     using SciMLLogging: AbstractVerbosityPreset, Standard, @SciMLMessage
     import LinearAlgebra
     using Parameters: @unpack
@@ -47,6 +57,12 @@ module IRKGaussLegendre
 
     export IRKGL16, IRKAlgorithm
     export tcoeffs, CompiledFloats
+
+    # Reexported SciML common interface; approved via `reexports_allow` in test/qa/qa.jl.
+    export DEStats, EnsembleAnalysis, EnsembleDistributed, EnsembleProblem,
+        EnsembleSerial, EnsembleSolution, EnsembleSplitThreads, EnsembleSummary,
+        EnsembleThreads, NullParameters, ODEFunction, ODEProblem, ODESolution,
+        ReturnCode, remake, solve, successful_retcode
 
     @setup_workload begin
         @compile_workload begin

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,23 @@
 using SciMLTesting, IRKGaussLegendre, JET, Test
 
-run_qa(IRKGaussLegendre)
+# The SciML common interface IRKGaussLegendre deliberately reexports so that
+# `using IRKGaussLegendre` is enough to build and solve an ODE problem, as the README's
+# Quick Start does. Owned and documented upstream; kept in sync with the reexport
+# `export` block in src/IRKGaussLegendre.jl.
+const REEXPORTS = (
+    :DEStats, :EnsembleAnalysis, :EnsembleDistributed, :EnsembleProblem, :EnsembleSerial,
+    :EnsembleSolution, :EnsembleSplitThreads, :EnsembleSummary, :EnsembleThreads,
+    :NullParameters, :ODEFunction, :ODEProblem, :ODESolution, :ReturnCode, :remake,
+    :solve, :successful_retcode,
+)
+
+run_qa(IRKGaussLegendre; reexports_allow = REEXPORTS)
+
+@testset "Reexport surface" begin
+    # Every approved reexport must actually be reachable from `using IRKGaussLegendre`,
+    # so the allow-list cannot drift into approving names the package no longer provides.
+    @testset "$name" for name in REEXPORTS
+        @test name in names(IRKGaussLegendre)
+        @test isdefined(@__MODULE__, name)
+    end
+end


### PR DESCRIPTION
## What broke

`914e829` ("Migrate QA to SciMLTesting 2.4", #135) removed `@reexport using SciMLBase`
from `src/IRKGaussLegendre.jl`.

That reexport *was* this package's common-interface surface. Without it,
`names(IRKGaussLegendre)` is five entries — `IRKGL16`, `IRKAlgorithm`, `tcoeffs`,
`CompiledFloats` and the module — and the README's own Quick Start fails with
`UndefVarError`:

```julia
using IRKGaussLegendre
prob = ODEProblem(harmonic!, u0, tspan)   # UndefVarError: `ODEProblem` not defined
sol = solve(prob, IRKGL16(second_order_ode = true); dt = 1.0, adaptive = false)
```

The docs Quick Start (`docs/src/index.md`) and the Pythagorean three-body example are in
the same position: both `using IRKGaussLegendre` and then call `ODEProblem`/`solve`. CI
never noticed because `test/main_tests.jl` and `test/alloc_tests.jl` import `SciMLBase`
explicitly.

## What this PR does

Per the org rule ("reexport what is normal documented use, but not whole dependencies"),
this follows SciML/Sundials.jl#553: an explicit `export` list rather than a restored
blanket reexport.

## Evidence used to pick the names

1. `README.md` — the Quick Start (`using IRKGaussLegendre` → `ODEProblem` → `solve`) and
   the "Return Codes" section, which documents `ReturnCode` as part of the public
   contract.
2. `docs/src/index.md` and `docs/src/examples/pythagorean_three_body.md` — same shape.
3. `src/IRKGL16Solver.jl` — what the solver actually implements: `SciMLBase.__solve` only,
   building an `ODESolution` with `DEStats`; no `__init`, no `callback` handling.

## Restored names (17)

`DEStats`, `EnsembleAnalysis`, `EnsembleDistributed`, `EnsembleProblem`, `EnsembleSerial`,
`EnsembleSolution`, `EnsembleSplitThreads`, `EnsembleSummary`, `EnsembleThreads`,
`NullParameters`, `ODEFunction`, `ODEProblem`, `ODESolution`, `ReturnCode`, `remake`,
`solve`, `successful_retcode`

Deliberately excluded: the callbacks and the iterator interface — `IRKGL16` implements
only `__solve` and honors no `callback` keyword, so `init`/`step!`/`CallbackSet` would
resolve to methods that cannot be used with it. `SecondOrderODEProblem` is out too:
second-order structure is requested through `IRKGL16(second_order_ode = true)` on an
ordinary `ODEProblem`. The remaining several hundred SciMLBase names stay dropped.

Every name is imported from SciMLBase, which owns it, so each stays documented upstream.

## Documentation

`docs/src/api.md` gains a **"Reexported SciML common interface"** section: names grouped
by role (problems / functions / solutions / ensembles / solving / return status),
SciMLBase named and linked as the owner, and an explicit boundary line saying what is
excluded and why.

## Drift protection

The docs list, the `export` block in `src/IRKGaussLegendre.jl` and the `REEXPORTS` tuple
in `test/qa/qa.jl` are the same list in three places. `qa.jl` declares it via
`reexports_allow`, and a new testset asserts every approved name is both in
`names(IRKGaussLegendre)` and actually in scope from `using IRKGaussLegendre`.

## Semver

Non-breaking. Only names that `using IRKGaussLegendre` provided before `914e829` are
added back; nothing is removed or changed in meaning. Minor bump. Version intentionally
not bumped here — a separate release pass handles it.

## Verification run locally

- `Pkg.test()` — green (`Core/alloc_tests.jl` 6/6, `Core/main_tests.jl` 4/4).
- `test/qa/qa.jl` — green: `Quality Assurance` 21/21 (including "No unapproved public
  reexports") and `Reexport surface` 34/34.
- `include("docs/make.jl")` — full docs build green with `checkdocs = :exports`.
- The README Quick Start verified end to end with `using IRKGaussLegendre` and no other
  import; `names(IRKGaussLegendre)` goes 5 → 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ